### PR TITLE
feat: changed the domain name and removed hyphen

### DIFF
--- a/vars/live.tfvars
+++ b/vars/live.tfvars
@@ -1,4 +1,4 @@
-external_zone = "self-service.global.com"
+external_zone = "selfservice.global.com"
 
 # This is the list which maintains the delegated hosted zone namespaces
 # We can get this list once you execute the base repo terraform modules


### PR DESCRIPTION
# What?

The self service team PO's need the urls to be named as selfservice.global.com that is without a hyphen.